### PR TITLE
Support `Dark content` for Status Bar in iOS 13

### DIFF
--- a/PlistDemo/Yellow.plist
+++ b/PlistDemo/Yellow.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>UIStatusBarStyle</key>
-	<string>Default</string>
+	<string>DarkContent</string>
 	<key>Global</key>
 	<dict>
 		<key>backgroundColor</key>

--- a/Sources/ThemeStatusBarStylePicker.swift
+++ b/Sources/ThemeStatusBarStylePicker.swift
@@ -50,6 +50,7 @@ final class ThemeStatusBarStylePicker: ThemePicker {}
         switch stringStyle.lowercased() {
         case "default"      : return .default
         case "lightcontent" : return .lightContent
+        case "darkcontent"  : if #available(iOS 13.0, *) { return .darkContent } else { return .default }
         default: return .default
         }
     }


### PR DESCRIPTION
- Support `.darkContent` for status bar
- Add mock case in `PlistDemo`