### PR TITLE
UINavigationBarAppearance support for iOS 13.

### DIFF
--- a/Sources/NSObject+Theme.swift
+++ b/Sources/NSObject+Theme.swift
@@ -41,7 +41,7 @@ extension NSObject {
     
     func performThemePicker(selector: String, picker: ThemePicker?) {
         let sel = Selector(selector)
-        
+
         guard responds(to: sel)           else { return }
         guard let value = picker?.value() else { return }
         
@@ -117,6 +117,12 @@ extension NSObject {
         themePickers.forEach { selector, picker in
             UIView.animate(withDuration: ThemeManager.animationDuration) {
                 self.performThemePicker(selector: selector, picker: picker)
+                // For iOS 13, force an update of the nav bar when the theme changes.
+                if #available(iOS 13.0, *) {
+                    if let navBar = self as? UINavigationBar {
+                        navBar.setNeedsLayout()
+                    }
+                }
             }
         }
     }

--- a/Sources/ThemeBlurEffectPicker.swift
+++ b/Sources/ThemeBlurEffectPicker.swift
@@ -1,0 +1,38 @@
+//
+//  ThemeBlurEffectPicker.swift
+//  SwiftTheme
+//
+//  Created by Kevin on 10/2/19.
+//
+
+import UIKit
+
+@objc public final class ThemeBlurEffectPicker: ThemePicker {
+
+    public convenience init(keyPath: String, map: @escaping (Any?) -> UIBlurEffect?) {
+        self.init(v: { map(ThemeManager.value(for: keyPath)) })
+    }
+
+    public convenience init(appearances: UIBlurEffect...) {
+        self.init(v: { ThemeManager.element(for: appearances) })
+    }
+
+    public required convenience init(arrayLiteral elements: UIBlurEffect...) {
+        self.init(v: { ThemeManager.element(for: elements) })
+    }
+
+}
+
+@objc public extension ThemeBlurEffectPicker {
+
+    class func pickerWithKeyPath(_ keyPath: String, map: @escaping (Any?) -> UIBlurEffect?) -> ThemeBlurEffectPicker {
+        return ThemeBlurEffectPicker(v: { map(ThemeManager.value(for: keyPath)) })
+    }
+
+    class func pickerWithAppearances(_ appearances: [UIBlurEffect]) -> ThemeBlurEffectPicker {
+        return ThemeBlurEffectPicker(v: { ThemeManager.element(for: appearances) })
+    }
+
+}
+
+extension ThemeBlurEffectPicker: ExpressibleByArrayLiteral {}

--- a/Sources/ThemeNavigationBarAppearancePicker.swift
+++ b/Sources/ThemeNavigationBarAppearancePicker.swift
@@ -1,0 +1,41 @@
+//
+//  ThemeNavigationBarAppearancePicker.swift
+//  SwiftTheme
+//
+//  Created by Kevin on 10/2/19.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+@objc public final class ThemeNavigationBarAppearancePicker: ThemePicker {
+
+    public convenience init(keyPath: String, map: @escaping (Any?) -> UINavigationBarAppearance?) {
+        self.init(v: { map(ThemeManager.value(for: keyPath)) })
+    }
+
+    public convenience init(appearances: UINavigationBarAppearance...) {
+        self.init(v: { ThemeManager.element(for: appearances) })
+    }
+
+    public required convenience init(arrayLiteral elements: UINavigationBarAppearance...) {
+        self.init(v: { ThemeManager.element(for: elements) })
+    }
+
+}
+
+@available(iOS 13.0, *)
+@objc public extension ThemeNavigationBarAppearancePicker {
+
+    class func pickerWithKeyPath(_ keyPath: String, map: @escaping (Any?) -> UINavigationBarAppearance?) -> ThemeNavigationBarAppearancePicker {
+        return ThemeNavigationBarAppearancePicker(v: { map(ThemeManager.value(for: keyPath)) })
+    }
+
+    class func pickerWithAppearances(_ appearances: [UINavigationBarAppearance]) -> ThemeNavigationBarAppearancePicker {
+        return ThemeNavigationBarAppearancePicker(v: { ThemeManager.element(for: appearances) })
+    }
+
+}
+
+@available(iOS 13.0, *)
+extension ThemeNavigationBarAppearancePicker: ExpressibleByArrayLiteral {}

--- a/Sources/UIKit+Theme.swift
+++ b/Sources/UIKit+Theme.swift
@@ -93,6 +93,21 @@ import UIKit
         get { return getThemePicker(self, "setLargeTitleTextAttributes:") as? ThemeStringAttributesPicker }
         set { setThemePicker(self, "setLargeTitleTextAttributes:", newValue) }
     }
+    @available(iOS 13.0, *)
+    var theme_standardAppearance: ThemeNavigationBarAppearancePicker? {
+        get { return getThemePicker(self, "setStandardAppearance:") as? ThemeNavigationBarAppearancePicker }
+        set { setThemePicker(self, "setStandardAppearance:", newValue) }
+    }
+    @available(iOS 13.0, *)
+    var theme_compactAppearance: ThemeNavigationBarAppearancePicker? {
+        get { return getThemePicker(self, "setCompactAppearance:") as? ThemeNavigationBarAppearancePicker }
+        set { setThemePicker(self, "setCompactAppearance:", newValue) }
+    }
+    @available(iOS 13.0, *)
+    var theme_scrollEdgeAppearance: ThemeNavigationBarAppearancePicker? {
+        get { return getThemePicker(self, "setScrollEdgeAppearance:") as? ThemeNavigationBarAppearancePicker }
+        set { setThemePicker(self, "setScrollEdgeAppearance:", newValue) }
+    }
 }
 @objc public extension UITabBar
 {
@@ -342,6 +357,46 @@ import UIKit
     var theme_effect: ThemeVisualEffectPicker? {
         get { return getThemePicker(self, "setEffect:") as? ThemeVisualEffectPicker }
         set { setThemePicker(self, "setEffect:", newValue) }
+    }
+}
+@available(iOS 13.0, *)
+public extension UINavigationBarAppearance
+{
+    var theme_titleTextAttributes: ThemeStringAttributesPicker? {
+        get { return getThemePicker(self, "setTitleTextAttributes:") as? ThemeStringAttributesPicker }
+        set { setThemePicker(self, "setTitleTextAttributes:", newValue) }
+    }
+    var theme_largeTitleTextAttributes: ThemeStringAttributesPicker? {
+        get { return getThemePicker(self, "setLargeTitleTextAttributes:") as? ThemeStringAttributesPicker }
+        set { setThemePicker(self, "setLargeTitleTextAttributes:", newValue) }
+    }
+    var theme_backIndicatorImage: ThemeImagePicker? {
+        get { return getThemePicker(self, "setBackIndicatorImage:") as? ThemeImagePicker }
+        set { setThemePicker(self, "setBackIndicatorImage:", newValue) }
+    }
+}
+@available(iOS 13.0, *)
+@objc public extension UIBarAppearance
+{
+    var theme_backgroundColor: ThemeColorPicker? {
+        get { return getThemePicker(self, "setBackgroundColor:") as? ThemeColorPicker }
+        set { setThemePicker(self, "setBackgroundColor:", newValue) }
+    }
+    var theme_backgroundImage: ThemeImagePicker? {
+        get { return getThemePicker(self, "setBackgroundImage:") as? ThemeImagePicker }
+        set { setThemePicker(self, "setBackgroundImage:", newValue) }
+    }
+    var theme_backgroundEffect: ThemeBlurEffectPicker? {
+        get { return getThemePicker(self, "setBackgroundEffect:") as? ThemeBlurEffectPicker }
+        set { setThemePicker(self, "setBackgroundEffect:", newValue) }
+    }
+    var theme_shadowColor: ThemeColorPicker? {
+        get { return getThemePicker(self, "setShadowColor:") as? ThemeColorPicker }
+        set { setThemePicker(self, "setShadowColor:", newValue) }
+    }
+    var theme_shadowImage: ThemeImagePicker? {
+        get { return getThemePicker(self, "setShadowImage:") as? ThemeImagePicker }
+        set { setThemePicker(self, "setShadowImage:", newValue) }
     }
 }
 #endif


### PR DESCRIPTION
* Add theme pickers for UIBlurEffect and UINavigationBarAppearance.
* Add theme support for new iOS 13 properties on UINavigationBar, UINavigationBarAppearance, UIBarAppearance.
* For iOS 13, force display update for theme changes to UINavigationBar.

iOS 13 does not appear to update an existing UINavigationBar when its properties are changed.  I had to force the update.  Hopefully, Apple will change this behavior in an upcoming release.