### PR TITLE
Add theme_attributesTexts for UILabel

### DIFF
--- a/Sources/UIKit+Theme.swift
+++ b/Sources/UIKit+Theme.swift
@@ -72,6 +72,10 @@ import UIKit
         get { return getThemePicker(self, "updateTextAttributes:") as? ThemeStringAttributesPicker }
         set { setThemePicker(self, "updateTextAttributes:", newValue) }
     }
+    var theme_attributesTexts: ThemeAttributedStringPicker? {
+        get { return getThemePicker(self, "setAttributedText:") as? ThemeAttributedStringPicker }
+        set { setThemePicker(self, "setAttributedText:", newValue) }
+    }
 }
 @objc public extension UINavigationBar
 {


### PR DESCRIPTION
theme_attributesTexts is used for UILabel's attributesText when it is splicing together multiple attribute pieces of text