### PR TITLE
add ThemeTabBarAppearancePicker + theme_standart/compact/scrollEdgeAppearance

### DIFF
--- a/Sources/ThemeTabBarAppearancePicker.swift
+++ b/Sources/ThemeTabBarAppearancePicker.swift
@@ -1,0 +1,42 @@
+//
+//  ThemeTabBarAppearancePicker.swift
+//  
+//
+//  Created by Ruslan Popesku on 15.10.2021.
+//
+
+import UIKit
+
+@available(iOS 13.0, tvOS 13.0, *)
+@objc public final class ThemeTabBarAppearancePicker: ThemePicker {
+
+    public convenience init(keyPath: String, map: @escaping (Any?) -> UITabBarAppearance?) {
+        self.init(v: { map(ThemeManager.value(for: keyPath)) })
+    }
+
+    public convenience init(appearances: UITabBarAppearance...) {
+        self.init(v: { ThemeManager.element(for: appearances) })
+    }
+
+    public required convenience init(arrayLiteral elements: UITabBarAppearance...) {
+        self.init(v: { ThemeManager.element(for: elements) })
+    }
+
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+@objc public extension ThemeTabBarAppearancePicker {
+
+    class func pickerWithKeyPath(_ keyPath: String, map: @escaping (Any?) -> UITabBarAppearance?) -> ThemeTabBarAppearancePicker {
+        ThemeTabBarAppearancePicker(keyPath: keyPath, map: map)
+    }
+
+    class func pickerWithAppearances(_ appearances: [UITabBarAppearance]) -> ThemeTabBarAppearancePicker {
+        ThemeTabBarAppearancePicker(v: { ThemeManager.element(for: appearances) })
+    }
+
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension ThemeTabBarAppearancePicker: ExpressibleByArrayLiteral {}
+

--- a/Sources/UIKit+Theme.swift
+++ b/Sources/UIKit+Theme.swift
@@ -129,6 +129,22 @@ import UIKit
         get { return getThemePicker(self, "setBarTintColor:") as? ThemeColorPicker }
         set { setThemePicker(self, "setBarTintColor:", newValue) }
     }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    var theme_standardAppearance: ThemeTabBarAppearancePicker? {
+        get { return getThemePicker(self, "setStandardAppearance:") as? ThemeTabBarAppearancePicker }
+        set { setThemePicker(self, "setStandardAppearance:", newValue) }
+    }
+    @available(iOS 13.0, tvOS 13.0, *)
+    var theme_compactAppearance: ThemeTabBarAppearancePicker? {
+        get { return getThemePicker(self, "setCompactAppearance:") as? ThemeTabBarAppearancePicker }
+        set { setThemePicker(self, "setCompactAppearance:", newValue) }
+    }
+    @available(iOS 13.0, tvOS 13.0, *)
+    var theme_scrollEdgeAppearance: ThemeTabBarAppearancePicker? {
+        get { return getThemePicker(self, "setScrollEdgeAppearance:") as? ThemeTabBarAppearancePicker }
+        set { setThemePicker(self, "setScrollEdgeAppearance:", newValue) }
+    }
 }
 @objc public extension UITabBarItem
 {


### PR DESCRIPTION
Required changes for setting appearance at iOS 15 for UITabBar.
Here is a trouble, caused be new iOS 15 transparent appearance: 
https://stackoverflow.com/questions/68688270/ios-15-uitabbarcontrollers-tabbar-background-color-turns-black

It were not possible to  use proposed decisions from stackoverflow while using SwiftTheme. That is why I've decided to implement missing scrollEdgeAppearance behaviour here.